### PR TITLE
Add basic Terraform validation test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: Terraform Validation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v2
+      - run: ./tests/test_basics.sh

--- a/tests/test_basics.sh
+++ b/tests/test_basics.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+terraform -chdir=terraform-learning/01-basics validate


### PR DESCRIPTION
## Summary
- add script running `terraform validate` in the basics example
- run validation script in GitHub Actions CI

## Testing
- `./tests/test_basics.sh` *(fails: terraform: command not found)*
- `apt-get update >/tmp/apt_update.log && tail -n 20 /tmp/apt_update.log` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a78c9b8e4c8321977ff8e080712086