### PR TITLE
feat: add variable and module lessons

### DIFF
--- a/terraform-learning/02-variables/README.md
+++ b/terraform-learning/02-variables/README.md
@@ -1,0 +1,28 @@
+# 02 - Working with Variables 🧮
+
+Learn how to make your Terraform configurations flexible using input variables and local values.
+
+## 🎯 What You'll Learn
+
+- Defining input variables
+- Setting default values and types
+- Using variables in resource definitions
+- Overriding variables with `terraform.tfvars`
+- Local values for intermediate calculations
+
+## 🚀 Try It Out
+
+1. Review `variables.tf` to see variable definitions
+2. Update `terraform.tfvars` with your own values
+3. Run `terraform plan` to preview changes
+4. Apply with `terraform apply`
+
+## 📁 Files in This Module
+
+- `main.tf` - Uses variables to configure resources
+- `variables.tf` - Declares input variables
+- `terraform.tfvars.example` - Example variable values file
+
+## 🎉 Next Steps
+
+Experiment by adding new variables or changing defaults. When you're ready, continue to **03-modules** to learn about creating reusable infrastructure.

--- a/terraform-learning/02-variables/main.tf
+++ b/terraform-learning/02-variables/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = var.bucket_name
+}
+

--- a/terraform-learning/02-variables/terraform.tfvars.example
+++ b/terraform-learning/02-variables/terraform.tfvars.example
@@ -1,0 +1,2 @@
+region      = "us-east-1"
+bucket_name = "my-example-bucket"

--- a/terraform-learning/02-variables/variables.tf
+++ b/terraform-learning/02-variables/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "AWS region to deploy to"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "bucket_name" {
+  description = "Name for the S3 bucket"
+  type        = string
+}
+

--- a/terraform-learning/03-modules/README.md
+++ b/terraform-learning/03-modules/README.md
@@ -1,0 +1,26 @@
+# 03 - Terraform Modules 🧱
+
+Modules help you organize and reuse infrastructure code. In this lesson you'll create a simple module and call it from your root configuration.
+
+## 🎯 What You'll Learn
+
+- Module structure and source paths
+- Passing variables to modules
+- Organizing reusable components
+
+## 🚀 Try It Out
+
+1. Inspect the module in `modules/simple-instance`
+2. Review `main.tf` to see how the module is called
+3. Adjust variables in `variables.tf`
+4. Run `terraform plan` and `terraform apply`
+
+## 📁 Files in This Module
+
+- `main.tf` - Calls the local module
+- `variables.tf` - Inputs passed to the module
+- `modules/simple-instance` - Example module creating an EC2 instance
+
+## 🎉 Next Steps
+
+Experiment with creating additional modules or converting existing configurations into modules. Continue to **04-state** to learn how Terraform tracks your infrastructure.

--- a/terraform-learning/03-modules/main.tf
+++ b/terraform-learning/03-modules/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.region
+}
+
+module "server" {
+  source        = "./modules/simple-instance"
+  ami           = var.ami
+  instance_type = var.instance_type
+}
+

--- a/terraform-learning/03-modules/modules/simple-instance/main.tf
+++ b/terraform-learning/03-modules/modules/simple-instance/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "this" {
+  ami           = var.ami
+  instance_type = var.instance_type
+}
+

--- a/terraform-learning/03-modules/modules/simple-instance/variables.tf
+++ b/terraform-learning/03-modules/modules/simple-instance/variables.tf
@@ -1,0 +1,10 @@
+variable "ami" {
+  description = "AMI ID"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+

--- a/terraform-learning/03-modules/variables.tf
+++ b/terraform-learning/03-modules/variables.tf
@@ -1,0 +1,17 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ami" {
+  description = "AMI ID for the instance"
+  type        = string
+}
+


### PR DESCRIPTION
## Summary
- add 02-variables lesson with examples of using input variables
- introduce 03-modules lesson showing a simple reusable module

## Testing
- `terraform fmt -check -recursive` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y terraform` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a810d8c6c883219abe4e8f9fb275f0